### PR TITLE
Add showdown stage to hand recorder flow

### DIFF
--- a/client/src/pages/HandRecorder.tsx
+++ b/client/src/pages/HandRecorder.tsx
@@ -22,7 +22,6 @@ type GameStage =
   | 'flop'
   | 'turn'
   | 'river'
-  | 'showdown'
   | 'showdown-hands'
   | 'complete'
 type ActionType = 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'all-in'
@@ -177,10 +176,6 @@ export function HandRecorder() {
   }
 
   const getValidActions = (player: Player): ActionType[] => {
-    if (['showdown', 'showdown-hands', 'complete'].includes(gameState.gameStage)) {
-      return []
-    }
-
     const actions: ActionType[] = ['fold']
     const callAmount = gameState.currentBet - player.currentBet
 
@@ -330,14 +325,10 @@ export function HandRecorder() {
         openCardSelector('river')
         break
       case 'river':
-        state.gameStage = 'showdown'
-        break
-      case 'showdown':
         state.gameStage = 'showdown-hands'
         break
     }
-
-    if (!['complete', 'showdown', 'showdown-hands'].includes(state.gameStage)) {
+    if (state.gameStage !== 'complete' && state.gameStage !== 'showdown-hands') {
       const dealerIndex = state.players.findIndex(p => p.position === 'BTN')
       for (let i = 1; i < state.players.length; i++) {
         const nextIndex = (dealerIndex + i) % state.players.length
@@ -960,23 +951,6 @@ export function HandRecorder() {
                     </div>
                   )}
                 </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {gameState.gameStage === 'showdown' && (
-            <Card>
-              <CardHeader>
-                <CardTitle>Showdown</CardTitle>
-                <CardDescription>Record opponents' hole cards</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Button
-                  onClick={() => setGameState(prev => ({ ...prev, gameStage: 'showdown-hands' }))}
-                  className="w-full"
-                >
-                  Record Opponent Hands
-                </Button>
               </CardContent>
             </Card>
           )}

--- a/client/src/pages/HandRecorder.tsx
+++ b/client/src/pages/HandRecorder.tsx
@@ -177,6 +177,10 @@ export function HandRecorder() {
   }
 
   const getValidActions = (player: Player): ActionType[] => {
+    if (['showdown', 'showdown-hands', 'complete'].includes(gameState.gameStage)) {
+      return []
+    }
+
     const actions: ActionType[] = ['fold']
     const callAmount = gameState.currentBet - player.currentBet
 
@@ -581,9 +585,7 @@ export function HandRecorder() {
               <CardDescription>
                 {gameState.gameStage === 'showdown-hands'
                   ? "Select opponents' hole cards"
-                  : gameState.gameStage === 'showdown'
-                    ? 'Showdown'
-                    : `Current Action: ${currentPlayer?.name} (${currentPlayer?.position})`}
+                  : `Current Action: ${currentPlayer?.name} (${currentPlayer?.position})`}
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -922,7 +924,7 @@ export function HandRecorder() {
             </CardContent>
           </Card>
 
-        {currentPlayer && !['showdown', 'showdown-hands', 'complete'].includes(gameState.gameStage) && (
+        {currentPlayer && gameState.gameStage !== 'showdown-hands' && gameState.gameStage !== 'complete' && (
             <Card>
               <CardHeader>
                 <CardTitle>Player Action: {currentPlayer.name} ({currentPlayer.position})</CardTitle>

--- a/client/src/pages/HandRecorder.tsx
+++ b/client/src/pages/HandRecorder.tsx
@@ -16,7 +16,15 @@ import playerChips from "./chips.png";
 
 
 
-type GameStage = 'setup' | 'preflop' | 'flop' | 'turn' | 'river' | 'showdown-hands' | 'complete'
+type GameStage =
+  | 'setup'
+  | 'preflop'
+  | 'flop'
+  | 'turn'
+  | 'river'
+  | 'showdown'
+  | 'showdown-hands'
+  | 'complete'
 type ActionType = 'fold' | 'check' | 'call' | 'bet' | 'raise' | 'all-in'
 
 interface Player {
@@ -318,11 +326,14 @@ export function HandRecorder() {
         openCardSelector('river')
         break
       case 'river':
+        state.gameStage = 'showdown'
+        break
+      case 'showdown':
         state.gameStage = 'showdown-hands'
         break
     }
 
-    if (state.gameStage !== 'complete' && state.gameStage !== 'showdown-hands') {
+    if (!['complete', 'showdown', 'showdown-hands'].includes(state.gameStage)) {
       const dealerIndex = state.players.findIndex(p => p.position === 'BTN')
       for (let i = 1; i < state.players.length; i++) {
         const nextIndex = (dealerIndex + i) % state.players.length
@@ -570,7 +581,9 @@ export function HandRecorder() {
               <CardDescription>
                 {gameState.gameStage === 'showdown-hands'
                   ? "Select opponents' hole cards"
-                  : `Current Action: ${currentPlayer?.name} (${currentPlayer?.position})`}
+                  : gameState.gameStage === 'showdown'
+                    ? 'Showdown'
+                    : `Current Action: ${currentPlayer?.name} (${currentPlayer?.position})`}
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -909,7 +922,7 @@ export function HandRecorder() {
             </CardContent>
           </Card>
 
-          {currentPlayer && gameState.gameStage !== 'showdown-hands' && gameState.gameStage !== 'complete' && (
+        {currentPlayer && !['showdown', 'showdown-hands', 'complete'].includes(gameState.gameStage) && (
             <Card>
               <CardHeader>
                 <CardTitle>Player Action: {currentPlayer.name} ({currentPlayer.position})</CardTitle>
@@ -945,6 +958,23 @@ export function HandRecorder() {
                     </div>
                   )}
                 </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {gameState.gameStage === 'showdown' && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Showdown</CardTitle>
+                <CardDescription>Record opponents' hole cards</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  onClick={() => setGameState(prev => ({ ...prev, gameStage: 'showdown-hands' }))}
+                  className="w-full"
+                >
+                  Record Opponent Hands
+                </Button>
               </CardContent>
             </Card>
           )}


### PR DESCRIPTION
## Summary
- introduce explicit `showdown` stage alongside `showdown-hands`
- update round advancement logic to include showdown and skip actions during showdown phases
- adjust HandRecorder UI to handle the new showdown stage and add step to begin recording opponent hands

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 77 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1d712988324aa0c6b4a0b12a17f